### PR TITLE
Add ubuntu-20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Ubuntu 19.04.
 In addition, this image contains GCC 9 to check if LibrePCB can be built with
 a recent compiler.
 
+### `ubuntu-20.04`
+
+Based on Ubuntu 20.04, containing Qt from the official Ubuntu package
+repository. This image is intended to check if LibrePCB compiles on a standard
+Ubuntu 20.04.
+
 
 ## Updating Images
 

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:20.04
+
+# Install APT packages
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    clang \
+    curl \
+    dbus \
+    doxygen \
+    file \
+    g++ \
+    git \
+    graphviz \
+    libc++-dev \
+    libc++abi-dev \
+    libglu1-mesa-dev \
+    libqt5opengl5 \
+    libqt5opengl5-dev \
+    libqt5svg5-dev \
+    libqt5sql5-sqlite \
+    make \
+    openssl \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    qt5-default \
+    qtdeclarative5-dev \
+    qttools5-dev-tools \
+    qttranslations5-l10n \
+    wget \
+    xvfb \
+    zlib1g \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set Python3 as default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
+
+# Install Python packages
+RUN pip install \
+  "future==0.17.1" \
+  "flake8==3.7.7"
+
+# LibrePCB's unittests expect that there is a USERNAME environment variable
+ENV USERNAME="root"


### PR DESCRIPTION
Ubuntu 20.04 with Qt from the official repositories, to make sure LibrePCB builds and runs fine with the latest Ubuntu LTS.