### PR TITLE
Ubuntu 20.04: Add pkg-config, libquazip and googletest

### DIFF
--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libqt5opengl5-dev \
     libqt5svg5-dev \
     libqt5sql5-sqlite \
+    libquazip5-1 \
+    libquazip5-dev \
     make \
     openssl \
+    pkg-config \
     python3 \
     python3-pip \
     python3-setuptools \

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     file \
     g++ \
     git \
+    googletest \
+    googletest-tools \
     graphviz \
     libc++-dev \
     libc++abi-dev \


### PR DESCRIPTION
This allows testing dynamic linking as well in this container.