### PR TITLE
Ubuntu 20.04: Add quazip pkg-config file

### DIFF
--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -50,5 +50,8 @@ RUN pip install \
   "future==0.17.1" \
   "flake8==3.7.7"
 
+# Add missing pkg-config files
+ADD quazip.pc /usr/lib/pkgconfig/
+
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"

--- a/ubuntu-20.04/quazip.pc
+++ b/ubuntu-20.04/quazip.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${prefix}/lib/x86_64-linux-gnu/
+includedir=${prefix}/include
+
+Name: Quazip
+Description: Quazip Library
+Version:
+Libs: -lquazip5
+Cflags:
+Requires: Qt5Core


### PR DESCRIPTION
The current stable Ubuntu/Debian package for quazip does not yet
include a pkg-config file (because upstream only added that recently).
Therefore we simply add the file to the container ourselves.