### PR TITLE
Ubuntu 20.04: Add libpolyclipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ repository. This image is intended to check if LibrePCB compiles on a standard
 Ubuntu 20.04.
 
 In addition, this image contains necessary tools for dynamic linking of
-LibrePCB (pkg-config, libquazip5-dev, googletest).
+LibrePCB (pkg-config, libquazip5, libpolyclipping, googletest).
 
 
 ## Updating Images

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libqt5sql5-sqlite \
     libquazip5-1 \
     libquazip5-dev \
+    libpolyclipping22 \
+    libpolyclipping-dev \
     make \
     openssl \
     pkg-config \


### PR DESCRIPTION
Add libpolyclipping to Ubuntu 20.04 image.