### PR TITLE
Fix broken URL to get-pip.py for Python 2.7

### DIFF
--- a/debian-8/Dockerfile
+++ b/debian-8/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
   && python get-pip.py
 
 # Install Python packages

--- a/ubuntu-14.04/Dockerfile
+++ b/ubuntu-14.04/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
   && python get-pip.py
 
 # Install Python packages

--- a/ubuntu-16.04-qt5.12.3/Dockerfile
+++ b/ubuntu-16.04-qt5.12.3/Dockerfile
@@ -58,7 +58,7 @@ RUN wget -cq "$LINUXDEPLOYQT_URL" -O /linuxdeployqt.AppImage \
   && rm /linuxdeployqt.AppImage
 
 # Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
   && python get-pip.py
 
 # Install Python packages

--- a/ubuntu-16.04-qt5.14.2/Dockerfile
+++ b/ubuntu-16.04-qt5.14.2/Dockerfile
@@ -59,7 +59,7 @@ RUN wget -cq "$LINUXDEPLOYQT_URL" -O /linuxdeployqt.AppImage \
   && rm /linuxdeployqt.AppImage
 
 # Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
   && python get-pip.py
 
 # Install Python packages

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
+RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
   && python get-pip.py
 
 # Install Python packages


### PR DESCRIPTION
Yes I know that py2.7 is deprecated, please don't ask... :wink: