### PR TITLE
Ubuntu 20.04: Add libdxflib

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ repository. This image is intended to check if LibrePCB compiles on a standard
 Ubuntu 20.04.
 
 In addition, this image contains necessary tools for dynamic linking of
-LibrePCB (pkg-config, libquazip5, libpolyclipping, googletest).
+LibrePCB (pkg-config, libdxflib, libquazip5, libpolyclipping, googletest).
 
 ### `windowsservercore-ltsc2019-qt5.15.0-32bit`
 

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     graphviz \
     libc++-dev \
     libc++abi-dev \
+    libdxflib3 \
+    libdxflib-dev \
     libglu1-mesa-dev \
     libqt5opengl5 \
     libqt5opengl5-dev \


### PR DESCRIPTION
We'll need dxflib for the DXF import feature (https://github.com/LibrePCB/LibrePCB/issues/891). To test unbundling it on CI, we need to have it installed in the Ubuntu 20.04 image - just like we already test unbundling of other libraries.