### PR TITLE
Update various tools in Windows image

### DIFF
--- a/windowsservercore-ltsc2019-qt5.15.2-32bit/Dockerfile
+++ b/windowsservercore-ltsc2019-qt5.15.2-32bit/Dockerfile
@@ -21,7 +21,7 @@ RUN powershell -Command Invoke-WebRequest $env:MINGW_URL -OutFile 'C:/tmp.7z' -U
   && del C:\tmp.7z
 
 # Install OpenSSL
-ARG OPENSSL_URL="http://slproweb.com/download/Win32OpenSSL_Light-1_1_1g.exe"
+ARG OPENSSL_URL="http://slproweb.com/download/Win32OpenSSL_Light-1_1_1L.exe"
 RUN powershell -Command Invoke-WebRequest $env:OPENSSL_URL -OutFile 'C:/tmp.exe' -UseBasicParsing ; \
   && C:/tmp.exe /silent /verysilent /suppressmsgboxes /sp- /dir=C:/OpenSSL-Win32 \
   && del C:\tmp.exe


### PR DESCRIPTION
- Update Python from 2.7 to 3.10 because Funq now finally works on Python 3
- Do not install any Python packages anymore since we don't need them
- Install CMake with Chocolatey instead of from Qt because the Qt URL is not static so the Docker image was not reproducible (it didn't build anymore due to broken URL)
- Update OpenSSL from 1.1.1g to 1.1.1L, just to stay up to date
- ~~Update Qt Installer Framework from 3.2.2 to 4.1.1 since it heavily improves headless installation of Qt installers~~

~~TODO: Verify that the LibrePCB installer is still working with the new Qt Installer Framework, and users can still update LibrePCB with the old installer.~~