### PR TITLE
Ubuntu 18.04: Switch from Python 2.7 to Python 3.6

### DIFF
--- a/ubuntu-18.04/Dockerfile
+++ b/ubuntu-18.04/Dockerfile
@@ -23,10 +23,10 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libqt5sql5-sqlite \
     make \
     openssl \
-    python \
-    python-pip \
-    python-setuptools \
-    python-wheel \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
     qt5-default \
     qtdeclarative5-dev \
     qtdeclarative5-qtquick2-plugin \
@@ -38,10 +38,9 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Python packages
-RUN pip install \
-  "future==0.17.1" \
-  "flake8==3.7.7"
+# Set Python3 as default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
 
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"


### PR DESCRIPTION
Because in Funq we (finally) dropped support for Python 2. Using Python 3.6.9 from the official Ubuntu repos now.

In addition, no longer installing Python packages we actually don't need in this image anymore.