### PR TITLE
Add more functionality and safety to build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,19 @@ Same purpose as `windowsservercore-ltsc2019-qt5.15.0-32bit`, but with Qt 5.15.2.
 
 ## Updating Images
 
+**Important: On Linux, use the helper script `./build.sh` since it makes the
+procedure less error prone!**
+
 1. Add/modify the Dockerfiles, update this README and commit all changes.
-2. Run `./build.sh <image-tag> <version> --push` to build and push the image.
-   Make sure to pass a version number which does not yet exist on Docker Hub!
+2. Run `./build.sh <image-name> <version> --push` to build and push the image.
+   Use the next unused version number, i.e. the previous image version plus one.
    Use just a single number as version identifier, e.g. `1`, `2`, `3`. Semantic
    versioning is not needed since CI always links to one specific version.
-3. Add and push a Git tag with the exact image tag (e.g. `ubuntu-18.04-1`).
+3. Test the new image by pushing the LibrePCB repository to trigger the CI.
+4. If everything was successful, merge the changes into `master`.
+5. On the `master` branch (merge commit checked out!), create the corresponding
+   Git tag by running `./build.sh <image-name> <version> --tag` (can also be
+   combined with `--push` to push the image again).
 
 
 ## Using Images Locally

--- a/build.sh
+++ b/build.sh
@@ -5,19 +5,59 @@ set -eu -o pipefail
 
 # Usage:
 #
-#   ./build.sh <tag> <version> [--push]
+#   ./build.sh <name> <version> [--push] [--tag]
 #
 # Example:
 #
 #   ./build.sh ubuntu-18.04 2 --push
 
-TAG="$1"
+NAME="$1"
 VERSION="$2"
-FLAG="${3-}"
+DO_PUSH=0
+DO_TAG=0
+for i in "$@"
+do
+case $i in
+  --push)
+  DO_PUSH=1
+  shift
+  ;;
+  --tag)
+  DO_TAG=1
+  shift
+  ;;
+esac
+done
 
-docker build -t librepcb/librepcb-dev:$TAG-$VERSION $TAG
+echo "Build image $NAME-$VERSION..."
+docker build --pull -t librepcb/librepcb-dev:$NAME-$VERSION $NAME
 
-if [ "$FLAG" = "--push" ]
+if [ "$DO_PUSH" == 1 ]
 then
-  docker push librepcb/librepcb-dev:$TAG-$VERSION
+  # Fail if the corresponding Git tag exists, since this means that the
+  # image was already released and we must not overwrite released images.
+  if git rev-parse "$NAME-$VERSION" >/dev/null 2>&1
+  then
+    echo "ERROR: This image is already released (Git tag exists)!"
+    exit 1
+  fi
+
+  echo "Push image $NAME-$VERSION..."
+  docker push librepcb/librepcb-dev:$NAME-$VERSION
+fi
+
+if [ "$DO_TAG" == 1 ]
+then
+  # Fail if a branch other than master is checked out since we should create
+  # releases only from the master branch.
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  if [[ "$BRANCH" != "master" ]]
+  then
+    echo "ERROR: Releases must be created on master branch, not $BRANCH!"
+    exit 1
+  fi
+
+  echo "Create Git tag $NAME-$VERSION..."
+  git tag "$NAME-$VERSION"
+  git push origin "$NAME-$VERSION"
 fi


### PR DESCRIPTION
- Add `--tag` CLI flag to add the corresponding Git tag (useful to create releases without typos or copy&paste mistakes). Fails with error when a branch other than master is checked out, since releases should always be created on the master branch.
- Pass `--pull` to `docker build` to ensure we always base our images on the latest base image.
- Reject pushing images to Docker Registry if the corresponding Git tag already exists (i.e. image is officially released). Avoids overwriting released images by accident, but still allow overwriting (unreleased) images during development/testing phase.