### PR TITLE
Ubuntu 16.04: Switch from Python 2.7 to Python 3.10

### DIFF
--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     graphviz \
     libc++-dev \
     libc++abi-dev \
+    libffi-dev \
     libglu1-mesa-dev \
     libqt5opengl5 \
     libqt5opengl5-dev \
@@ -23,7 +24,6 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libqt5sql5-sqlite \
     make \
     openssl \
-    python \
     qt5-default \
     qtdeclarative5-dev \
     qtdeclarative5-qtquick2-plugin \
@@ -35,14 +35,43 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# Install PIP (the version from APT is not sufficient)
-RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" -o get-pip.py \
-  && python get-pip.py
+# Remove DST root certificate since it is not compatible with OpenSSL 1.0. This
+# is only needed for building the Docker image, afterwards we will have a newer
+# OpenSSL library.
+# See https://medium.com/geekculture/will-you-be-impacted-by-letsencrypt-dst-root-ca-x3-expiration-d54a018df257
+RUN sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' \
+  /etc/ca-certificates.conf && update-ca-certificates
 
-# Install Python packages
-RUN pip install \
-  "future==0.17.1" \
-  "flake8==3.7.7"
+# Install OpenSSL 1.1 for Python/pip.
+ARG OPENSSL_VERSION="1.1.1l"
+RUN wget -c "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" -O /tmp.tar.gz \
+  && tar -zxf /tmp.tar.gz \
+  && cd "./openssl-$OPENSSL_VERSION" \
+  && ./config --prefix=/usr --openssldir=/etc/ssl '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)' \
+  && make -s -j8 \
+  && make install > /dev/null \
+  && cd .. \
+  && rm -rf "./openssl-$OPENSSL_VERSION" \
+  && rm /tmp.tar.gz
+
+# Install Python & pip
+# Note: Actually Python 3.5 from the official Ubuntu repositories is
+# sufficient for us, but having a more recent version simplifies dependency
+# management since then we can drop support for Python 3.5.
+ARG PYTHON_VERSION="3.10.0"
+RUN wget "https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz" \
+  && tar xzvf "./Python-$PYTHON_VERSION.tgz" \
+  && cd "./Python-$PYTHON_VERSION" \
+  && ./configure \
+  && make -j8 \
+  && make install \
+  && cd .. \
+  && rm -rf "./Python-$PYTHON_VERSION" \
+  && rm "./Python-$PYTHON_VERSION.tgz" \
+  && update-alternatives --install /usr/bin/python python /usr/local/bin/python3.10 100 \
+  && curl "https://bootstrap.pypa.io/pip/get-pip.py" -o get-pip.py \
+  && python get-pip.py \
+  && rm get-pip.py
 
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"


### PR DESCRIPTION
Because in Funq we (finally) dropped support for Python 2. Manually installing a recent Python version because Python 3.5 from the official Ubuntu repos might lead to troubles sooner or later since it is EOL already (however, at the moment it should actually be sufficient).

In addition, no longer installing Python packages we actually don't need in this image anymore.

In case the question arises why we still use Ubuntu 16.04: This particular image is not used for any productive purpose, but it is useful to check if LibrePCB compiles with the minimum Qt version 5.5 which we specify in our requirements. Without this CI job, it's too easy to break our own minimum requirements :wink: