### PR TITLE
Ubuntu 20.04: Add libmuparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ repository. This image is intended to check if LibrePCB compiles on a standard
 Ubuntu 20.04.
 
 In addition, this image contains necessary tools for dynamic linking of
-LibrePCB (pkg-config, libdxflib, libquazip5, libpolyclipping, googletest).
+LibrePCB (pkg-config, libdxflib, libmuparser, libquazip5, libpolyclipping,
+googletest).
 
 ### `windowsservercore-ltsc2019-qt5.15.0-32bit`
 

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libdxflib3 \
     libdxflib-dev \
     libglu1-mesa-dev \
+    libmuparser2v5 \
+    libmuparser-dev \
     libqt5opengl5 \
     libqt5opengl5-dev \
     libqt5svg5-dev \


### PR DESCRIPTION
To also allow testing the unbundling of muparser on CI.

Tested -> seems to work.