### PR TITLE
Ubuntu 20.04: Install libgtest-dev and libgmock-dev

### DIFF
--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     libdxflib3 \
     libdxflib-dev \
     libglu1-mesa-dev \
+    libgmock-dev \
+    libgtest-dev \
     libmuparser2v5 \
     libmuparser-dev \
     libqt5opengl5 \

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -63,5 +63,11 @@ RUN pip install \
 # Add missing pkg-config files
 ADD quazip.pc /usr/lib/pkgconfig/
 
+# Fix broken GTest/GMock pkg-config files, see
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=958099
+RUN sed -i -e 's/prefix=.*/prefix=\/usr/g' \
+  /usr/lib/x86_64-linux-gnu/pkgconfig/gtest*.pc \
+  /usr/lib/x86_64-linux-gnu/pkgconfig/gmock*.pc
+
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"


### PR DESCRIPTION
Allows to test unbundling of GTest/GMock. See https://github.com/LibrePCB/LibrePCB/issues/933.