### PR TITLE
Add new image "webtools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Windows.
 
 Same purpose as `windowsservercore-ltsc2019-qt5.15.0-32bit`, but with Qt 5.15.2.
 
+### `webtools`
+
+An image providing all the web tools we need for
+[`librepcb-doc`](https://github.com/LibrePCB/librepcb-doc) and
+[`librepcb-website`](https://github.com/LibrePCB/librepcb-website):
+
+* [Antora](https://antora.org/)
+* [Asciidoctor](https://asciidoctor.org/)
+* [Hugo](https://gohugo.io)
+
 
 ## Updating Images
 

--- a/webtools/Dockerfile
+++ b/webtools/Dockerfile
@@ -1,0 +1,31 @@
+# Get Antora by using it as the base image.
+FROM antora/antora:3.1.1
+
+# Install system packages.
+RUN apk add --no-cache \
+  gifsicle \
+  git \
+  imagemagick \
+  openssl \
+  pngcrush \
+  python3 \
+  ruby
+
+# Install the Antora PDF extension
+# See https://gitlab.com/antora/antora-assembler
+RUN yarn global add "@antora/pdf-extension@1.0.0-alpha.6" \
+  && rm -rf $(yarn cache dir)/* \
+  && gem install asciidoctor-pdf -v 2.3.2 \
+  && gem install rouge -v 4.0.0 \
+  && gem install pygments.rb -v 2.3.0
+
+# Install Hugo.
+ARG HUGO_VERSION=0.104.2
+ARG HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz"
+RUN mkdir ./hugo \
+  && cd ./hugo \
+  && wget -O "./hugo.tar.gz" "$HUGO_URL" \
+  && tar -xvzf ./hugo.tar.gz \
+  && mv ./hugo /usr/local/bin/hugo \
+  && cd .. \
+  && rm -rf ./hugo


### PR DESCRIPTION
A new image providing all the web tools we need for [`librepcb-doc`](https://github.com/LibrePCB/librepcb-doc) and [`librepcb-website`](https://github.com/LibrePCB/librepcb-website):

* [Antora](https://antora.org/)
* [Asciidoctor](https://asciidoctor.org/)
* [Hugo](https://gohugo.io)

Marked as draft as long as the transition to this image is work in progress.