### PR TITLE
Add ubuntu-18.04-qt5.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Based on Ubuntu 18.04, containing Qt from the official Ubuntu package
 repository. This image is intended to check if LibrePCB compiles on a standard
 Ubuntu 18.04.
 
+### `ubuntu-18.04-qt5.15.2`
+
+Based on Ubuntu 18.04, containing Qt 5.15.2 from
+[download.qt.io](https://download.qt.io). This image is intended for
+deployment of official binary releases of LibrePCB, which should be linked
+against an old version of `glibc` (for maximum compatibility) but still using
+a recent Qt version (to get the latest features/bugfixes of Qt).
+
+In addition, this image contains
+[`linuxdeployqt`](https://github.com/probonopd/linuxdeployqt) to build the
+AppImage.
+
 ### `ubuntu-19.04`
 
 Based on Ubuntu 19.04, containing Qt from the official Ubuntu package

--- a/ubuntu-18.04-qt5.15.2/Dockerfile
+++ b/ubuntu-18.04-qt5.15.2/Dockerfile
@@ -1,0 +1,127 @@
+FROM ubuntu:18.04
+
+# Install APT packages
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    dbus \
+    doxygen \
+    file \
+    g++ \
+    git \
+    graphviz \
+    libc++-dev \
+    libc++abi-dev \
+    libcups2 \
+    libegl1-mesa \
+    libffi-dev \
+    libfontconfig1 \
+    libfreetype6 \
+    libglu1-mesa-dev \
+    libodbc1 \
+    libpq5 \
+    libxcb-glx0 \
+    libxcb-icccm4 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-randr0 \
+    libxcb-render-util0 \
+    libxcb-shape0 \
+    libxcb-shm0 \
+    libxcb-xfixes0 \
+    libxcb-xinerama0 \
+    libxcb1 \
+    libxkbcommon-x11-0 \
+    make \
+    ninja-build \
+    p7zip-full \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    software-properties-common \
+    wget \
+    xvfb \
+    zlib1g \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set Python3 as default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
+
+# Install Qt Tools
+ARG QT_VERSION="5.15.2"
+ARG QT_URL="https://download.qt.io/online/qtsdkrepository/linux_x64/desktop/qt5_5152/qt.qt5.5152.gcc_64/5.15.2-0-202011130601"
+ENV QTDIR="/opt/qt/$QT_VERSION/gcc_64" \
+    PATH="/opt/qt/$QT_VERSION/gcc_64/bin:$PATH" \
+    LD_LIBRARY_PATH="/opt/qt/$QT_VERSION/gcc_64/lib:$LD_LIBRARY_PATH" \
+    PKG_CONFIG_PATH="/opt/qt/$QT_VERSION/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH"
+RUN mkdir /opt/qt \
+  && wget -c "${QT_URL}qttools-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && rm /tmp.7z \
+  # The AppImage deployment tools might read some paths from the Qt libraries,
+  # but they are wrong so let's create a symlink to make them working anyway:
+  && mkdir -p "/home/qt/work" \
+  && ln -s "/opt/qt/$QT_VERSION/gcc_64" "/home/qt/work/install"
+
+# Install Qt Base
+ARG QT_PRI="/opt/qt/$QT_VERSION/gcc_64/mkspecs/qconfig.pri"
+RUN wget -c "${QT_URL}qtbase-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && sed -i 's/Enterprise/OpenSource/' "$QT_PRI" \
+  && sed -i 's/licheck64//' "$QT_PRI" \
+  && rm /tmp.7z
+
+# Install Qt SVG
+RUN wget -c "${QT_URL}qtsvg-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && rm /tmp.7z
+
+# Install Qt Declarative
+RUN wget -c "${QT_URL}qtdeclarative-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && rm /tmp.7z
+
+# Install Qt Translations
+RUN wget -c "${QT_URL}qttranslations-Linux-RHEL_7_6-GCC-Linux-RHEL_7_6-X86_64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && rm /tmp.7z
+
+# Install libicu
+RUN wget -c "${QT_URL}icu-linux-Rhel7.2-x64.7z" -O /tmp.7z \
+  && 7za x /tmp.7z -o/opt/qt \
+  && rm /tmp.7z
+
+# Install linuxdeployqt
+ARG LINUXDEPLOYQT_VERSION="6"
+ARG LINUXDEPLOYQT_URL="https://github.com/probonopd/linuxdeployqt/releases/download/$LINUXDEPLOYQT_VERSION/linuxdeployqt-$LINUXDEPLOYQT_VERSION-x86_64.AppImage"
+RUN wget -c "$LINUXDEPLOYQT_URL" -O /linuxdeployqt.AppImage \
+  && chmod a+x /linuxdeployqt.AppImage \
+  && /linuxdeployqt.AppImage --appimage-extract \
+  && chmod -R 755 /squashfs-root \
+  && mv /squashfs-root /opt/linuxdeployqt \
+  && ln -s /opt/linuxdeployqt/AppRun /usr/local/bin/linuxdeployqt \
+  && rm /linuxdeployqt.AppImage
+
+# Install beta appimagetool which should not depend on any system libraries
+# anymore, and should therefore run on Ubuntu 22.04 which doesn't provide
+# libfuse2 anymore (see https://github.com/LibrePCB/LibrePCB/issues/980).
+# However, since there are no official releases yet, the binary is downloaded
+# from the nightly build and added to the repository. Download URL:
+# https://github.com/probonopd/go-appimage/releases/download/continuous/appimagetool-718-x86_64.AppImage
+COPY appimagetool-x86_64.AppImage /appimagetool-x86_64.AppImage
+RUN /appimagetool-x86_64.AppImage --appimage-extract \
+  && chmod -R 755 /squashfs-root \
+  && mv /squashfs-root /opt/appimagetool \
+  && ln -s /opt/appimagetool/AppRun /usr/local/bin/appimagetool \
+  && rm /appimagetool-x86_64.AppImage
+
+# LibrePCB's unittests expect that there is a USERNAME environment variable
+ENV USERNAME="root"


### PR DESCRIPTION
To get rid of the Ubuntu 16.04 image soon. Yes I known 18.04 is EOL soon, but it is the best option to build our official binary releases (maximum glibc compatibility).