### PR TITLE
Disable building of OCCT documentation

### DIFF
--- a/ubuntu-18.04-qt5.15.2/Dockerfile
+++ b/ubuntu-18.04-qt5.15.2/Dockerfile
@@ -80,6 +80,7 @@ RUN wget -c "${OCC_URL}" -O /tmp.tar.gz \
        -DCMAKE_BUILD_TYPE=Release \
        -DINSTALL_DIR=/usr \
        -DBUILD_LIBRARY_TYPE=Shared \
+       -DBUILD_DOC_Overview=0 \
        -DBUILD_MODULE_ApplicationFramework=0 \
        -DBUILD_MODULE_DataExchange=1 \
        -DBUILD_MODULE_Draw=0 \

--- a/ubuntu-20.04-qt6.6/Dockerfile
+++ b/ubuntu-20.04-qt6.6/Dockerfile
@@ -70,6 +70,7 @@ RUN wget -c "${OCC_URL}" -O /tmp.tar.gz \
        -DCMAKE_BUILD_TYPE=Release \
        -DINSTALL_DIR=/usr \
        -DBUILD_LIBRARY_TYPE=Shared \
+       -DBUILD_DOC_Overview=0 \
        -DBUILD_MODULE_ApplicationFramework=0 \
        -DBUILD_MODULE_DataExchange=1 \
        -DBUILD_MODULE_Draw=0 \

--- a/windowsservercore-ltsc2019-qt5.15.2-32bit/Dockerfile
+++ b/windowsservercore-ltsc2019-qt5.15.2-32bit/Dockerfile
@@ -34,6 +34,7 @@ RUN powershell -Command Invoke-WebRequest $env:OCC_URL -OutFile 'C:/tmp.zip' -Us
        -DCMAKE_BUILD_TYPE=Release \
        -DINSTALL_DIR=C:/OpenCascade \
        -DBUILD_LIBRARY_TYPE=Shared \
+       -DBUILD_DOC_Overview=0 \
        -DBUILD_MODULE_ApplicationFramework=0 \
        -DBUILD_MODULE_DataExchange=1 \
        -DBUILD_MODULE_Draw=0 \

--- a/windowsservercore-ltsc2019-qt6.6-64bit/Dockerfile
+++ b/windowsservercore-ltsc2019-qt6.6-64bit/Dockerfile
@@ -90,6 +90,7 @@ RUN powershell -Command Invoke-WebRequest $env:OCC_URL -OutFile 'C:/tmp.zip' -Us
        -DCMAKE_BUILD_TYPE=Release \
        -DINSTALL_DIR=C:/OpenCascade \
        -DBUILD_LIBRARY_TYPE=Shared \
+       -DBUILD_DOC_Overview=0 \
        -DBUILD_MODULE_ApplicationFramework=0 \
        -DBUILD_MODULE_DataExchange=1 \
        -DBUILD_MODULE_Draw=0 \


### PR DESCRIPTION
Not tested yet... Probably it has no effect anyway because Doxygen is not available in the Docker image, but it's still good to use the same OCCT build command as for deployment (e.g. Flatpak) so we can use it for reference.