### PR TITLE
Add Ubuntu 24.04 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ In addition, this image contains necessary tools for dynamic linking of
 LibrePCB (pkg-config, libdxflib, libmuparser, libquazip, libpolyclipping,
 googletest).
 
+### `ubuntu-24.04`
+
+Based on Ubuntu 24.04, containing Qt from the official Ubuntu package
+repository. This image is intended to check if LibrePCB compiles on a standard
+Ubuntu.
+
+In addition, this image contains necessary tools for dynamic linking of
+LibrePCB (pkg-config, libdxflib, libmuparser, libquazip, libpolyclipping,
+googletest).
+
 ### `windowsservercore-ltsc2019-qt6.6-64bit`
 
 Based on Windows Server Core LTSC2019 with Qt6.6.x, MinGW 11.2.0 64-bit

--- a/ubuntu-24.04/Dockerfile
+++ b/ubuntu-24.04/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:24.04
+
+# Install APT packages
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    cargo \
+    clang \
+    cmake \
+    curl \
+    dbus \
+    file \
+    g++ \
+    git \
+    googletest \
+    libc++-dev \
+    libc++abi-dev \
+    libdxflib-dev \
+    libdxflib3 \
+    libglu1-mesa-dev \
+    libgmock-dev \
+    libgtest-dev \
+    libmuparser-dev \
+    libmuparser2v5 \
+    libocct-*-dev \
+    libpolyclipping-dev \
+    libpolyclipping22 \
+    libqt6core5compat6-dev \
+    libqt6opengl6-dev \
+    libqt6openglwidgets6 \
+    libqt6sql6-sqlite \
+    libqt6svg6-dev \
+    libquazip1-qt6-1t64 \
+    libquazip1-qt6-dev \
+    libtbb-dev \
+    libxi-dev \
+    make \
+    ninja-build \
+    occt-misc \
+    openssl \
+    pkg-config \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    qt6-base-dev \
+    qt6-declarative-dev \
+    qt6-image-formats-plugins \
+    qt6-l10n-tools \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    rustc \
+    sccache \
+    wget \
+    xvfb \
+    zlib1g \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set Python3 as default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+
+# Allow installing pip packages system-wide since there's no risk in a container
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+# Make .cargo/ writable for everyone to allow running the container as non-root
+RUN mkdir /.cargo && chmod 777 /.cargo
+
+# LibrePCB's unittests expect that there is a USERNAME environment variable
+ENV USERNAME="root"


### PR DESCRIPTION
To make sure we also test on the current Ubuntu LTS. No longer contains Qt5, but now contains the Rust toolchain which we'll need for LibrePCB 2.x.