### PR TITLE
Ubuntu 22.04: Update from Qt5 to Qt6, install Rust toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ googletest).
 
 ### `ubuntu-22.04`
 
-Based on Ubuntu 22.04, containing Qt and OpenCascade OCE from the official
-Ubuntu package repository. This image is intended to check if LibrePCB
-compiles on a standard Ubuntu 22.04.
+Based on Ubuntu 22.04, containing Qt from the official Ubuntu package
+repository. This image is intended to check if LibrePCB compiles on a standard
+Ubuntu 22.04.
+
+In addition, this image contains necessary tools for dynamic linking of
+LibrePCB (pkg-config, libdxflib, libmuparser, libquazip, libpolyclipping,
+googletest).
 
 ### `windowsservercore-ltsc2019-qt6.6-64bit`
 

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -9,43 +9,44 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     cmake \
     curl \
     dbus \
-    doxygen \
     file \
     g++ \
     git \
-    graphviz \
+    googletest \
     libc++-dev \
     libc++abi-dev \
+    libdxflib-dev \
+    libdxflib3 \
     libglu1-mesa-dev \
-    liboce-*-dev \
-    libqt5opengl5 \
-    libqt5opengl5-dev \
-    libqt5sql5-sqlite \
-    libqt5svg5-dev \
+    libgmock-dev \
+    libgtest-dev \
+    libmuparser-dev \
+    libmuparser2v5 \
+    libocct-*-dev \
+    libpolyclipping-dev \
+    libpolyclipping22 \
     libqt6core5compat6-dev \
     libqt6opengl6-dev \
     libqt6openglwidgets6 \
     libqt6sql6-sqlite \
     libqt6svg6-dev \
+    libtbb2-dev \
+    libxi-dev \
     make \
     ninja-build \
+    occt-misc \
     openssl \
+    pkg-config \
     python3 \
     python3-pip \
     python3-setuptools \
     python3-wheel \
-    qt5-image-formats-plugins \
     qt6-base-dev \
     qt6-declarative-dev \
     qt6-image-formats-plugins \
     qt6-l10n-tools \
     qt6-tools-dev \
     qt6-tools-dev-tools \
-    qtbase5-dev \
-    qtdeclarative5-dev \
-    qtquickcontrols2-5-dev \
-    qttools5-dev \
-    qttools5-dev-tools \
     wget \
     xvfb \
     zlib1g \

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -5,6 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     bzip2 \
     ca-certificates \
+    cargo \
     clang \
     cmake \
     curl \
@@ -47,6 +48,7 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     qt6-l10n-tools \
     qt6-tools-dev \
     qt6-tools-dev-tools \
+    rustc \
     wget \
     xvfb \
     zlib1g \
@@ -58,6 +60,18 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 
 # Allow installing pip packages system-wide since there's no risk in a container
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+# Make .cargo/ writable for everyone to allow running the container as non-root
+RUN mkdir /.cargo && chmod 777 /.cargo
+
+# Install sccache
+ARG SCCACHE_VERSION="0.8.2"
+ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v$SCCACHE_VERSION/sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz"
+RUN wget -c "$SCCACHE_URL" -O /tmp.tar.gz \
+  && tar -zxf /tmp.tar.gz \
+  && cp "./sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache" /usr/local/bin/ \
+  && rm -rf "./sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl" \
+  && rm /tmp.tar.gz
 
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"


### PR DESCRIPTION
- Replace Qt5 by Qt6
- Install libraries for dynamic linking (quazip etc.)
- Install Rust toolchain & sccache
- Remove Doxygen as we don't need it in this image