### PR TITLE
Update Rust to 1.85.0 in all Ubuntu images

### DIFF
--- a/devtools/Dockerfile
+++ b/devtools/Dockerfile
@@ -3,19 +3,16 @@ FROM ubuntu:24.04
 # Install APT packages
 RUN apt-get -q update \
  && apt-get -qy install \
-  # Documentation tools: Doxygen, Graphviz, qhelpgenerator, rustdoc
+  # Documentation tools: Doxygen, Graphviz, qhelpgenerator
   doxygen \
   graphviz \
   qt6-documentation-tools \
-  rustc \
-  # Formatting tools: clang-format, qmlformat, rustfmt, xmlsort
+  # Formatting tools: clang-format, qmlformat, xmlsort
   clang-format-15 \
   libxml-filter-sort-perl \
-  rustfmt \
   qt6-declarative-dev-tools \
-  # Stylecheck tools: git, rust-clippy
+  # Stylecheck tools: git
   git \
-  rust-clippy \
   # Python for custom formatting scripts, flake8 etc.
   python3 \
   python3-debian \
@@ -32,6 +29,17 @@ RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/cl
 
 # Put qhelpgenerator in PATH
 RUN ln -s /usr/lib/qt6/libexec/qhelpgenerator /usr/local/bin/qhelpgenerator
+
+# Install Rust, including rustdoc, rustfmt, rust-clippy
+# Make .cargo/ writable for everyone to allow running the container as non-root.
+ARG RUST_VERSION="1.85.0"
+ENV RUSTUP_HOME="/.rustup" \
+    CARGO_HOME="/.cargo" \
+    PATH="/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain $RUST_VERSION --no-modify-path \
+  && chmod 777 $RUSTUP_HOME \
+  && chmod 777 $CARGO_HOME
 
 # Install Python packages
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/ubuntu-20.04-qt6.6/Dockerfile
+++ b/ubuntu-20.04-qt6.6/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     bzip2 \
     ca-certificates \
-    cargo \
     ccache \
     clang \
     curl \
@@ -47,7 +46,6 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     python3-pip \
     python3-setuptools \
     python3-wheel \
-    rustc \
     software-properties-common \
     wget \
     xvfb \
@@ -66,8 +64,16 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
 # Allow installing pip packages system-wide since there's no risk in a container
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# Make .cargo/ writable for everyone to allow running the container as non-root
-RUN mkdir /.cargo && chmod 777 /.cargo
+# Install Rust
+# Make .cargo/ writable for everyone to allow running the container as non-root.
+ARG RUST_VERSION="1.85.0"
+ENV RUSTUP_HOME="/.rustup" \
+    CARGO_HOME="/.cargo" \
+    PATH="/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain $RUST_VERSION --profile minimal --no-modify-path \
+  && chmod 777 $RUSTUP_HOME \
+  && chmod 777 $CARGO_HOME
 
 # Install CMake
 ARG CMAKE_VERSION="3.31.1"

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     bzip2 \
     ca-certificates \
-    cargo \
     ccache \
     clang \
     cmake \
@@ -49,7 +48,6 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     qt6-l10n-tools \
     qt6-tools-dev \
     qt6-tools-dev-tools \
-    rustc \
     wget \
     xvfb \
     zlib1g \
@@ -62,8 +60,16 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 # Allow installing pip packages system-wide since there's no risk in a container
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# Make .cargo/ writable for everyone to allow running the container as non-root
-RUN mkdir /.cargo && chmod 777 /.cargo
+# Install Rust
+# Make .cargo/ writable for everyone to allow running the container as non-root.
+ARG RUST_VERSION="1.85.0"
+ENV RUSTUP_HOME="/.rustup" \
+    CARGO_HOME="/.cargo" \
+    PATH="/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain $RUST_VERSION --profile minimal --no-modify-path \
+  && chmod 777 $RUSTUP_HOME \
+  && chmod 777 $CARGO_HOME
 
 # Install sccache
 ARG SCCACHE_VERSION="0.8.2"

--- a/ubuntu-24.04/Dockerfile
+++ b/ubuntu-24.04/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     bzip2 \
     ca-certificates \
-    cargo \
     ccache \
     clang \
     cmake \
@@ -51,7 +50,6 @@ RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     qt6-l10n-tools \
     qt6-tools-dev \
     qt6-tools-dev-tools \
-    rustc \
     sccache \
     wget \
     xvfb \
@@ -65,8 +63,16 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 # Allow installing pip packages system-wide since there's no risk in a container
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# Make .cargo/ writable for everyone to allow running the container as non-root
-RUN mkdir /.cargo && chmod 777 /.cargo
+# Install Rust
+# Make .cargo/ writable for everyone to allow running the container as non-root.
+ARG RUST_VERSION="1.85.0"
+ENV RUSTUP_HOME="/.rustup" \
+    CARGO_HOME="/.cargo" \
+    PATH="/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain $RUST_VERSION --profile minimal --no-modify-path \
+  && chmod 777 $RUSTUP_HOME \
+  && chmod 777 $CARGO_HOME
 
 # LibrePCB's unittests expect that there is a USERNAME environment variable
 ENV USERNAME="root"


### PR DESCRIPTION
Recent Slint releases require at least Rust 1.82 so we have to switch from APT packages to Rustup to get a recent Rust toolchain...

Closes #54 