### PR TITLE
Ubuntu 20.04/Qt6.6: Fix OpenSSL 3 deployment

### DIFF
--- a/ubuntu-20.04-qt6.6/Dockerfile
+++ b/ubuntu-20.04-qt6.6/Dockerfile
@@ -211,14 +211,15 @@ RUN /appimagetool-x86_64.AppImage --appimage-extract \
 
 # Install latest OpenSSL to avoid possible issues if servers some day stop
 # working with an old OpenSSL library (as already happened in the past).
-ARG OPENSSL_VERSION="3.4.0"
-RUN wget -c "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" -O /tmp.tar.gz \
+ARG OPENSSL_VERSION="3.4.1"
+ENV LD_LIBRARY_PATH="/opt/openssl/lib:$LD_LIBRARY_PATH"
+RUN apt-get remove -y libssl-dev \
+  && wget -c "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" -O /tmp.tar.gz \
   && tar -zxf /tmp.tar.gz \
   && cd "./openssl-$OPENSSL_VERSION" \
-  && ./config --prefix=/usr --libdir=lib --openssldir=/etc/ssl '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)' \
-  && make -s -j8 \
-  && make install \
-  && ldconfig \
+  && ./config --prefix=/opt/openssl --libdir=lib --openssldir=/opt/openssl/etc/ssl \
+  && make -j8 \
+  && make install_sw \
   && cd .. \
   && rm -rf "./openssl-$OPENSSL_VERSION" \
   && rm /tmp.tar.gz


### PR DESCRIPTION
Install libssl to a dedicated location `/opt/openssl` and set `LD_LIBRARY_PATH` accordingly to avoid deployment issues. Also update it to the latest version and stop installing manpages.

And removed the linker flags `-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)` though I don't know if that makes sense or not. I'd expect building with default flags should be the best :thinking: 

Required for https://github.com/LibrePCB/LibrePCB/issues/1480